### PR TITLE
Add cmake support and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+.cache/
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(redscript)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_compile_options(-Wall -Wextra)
+
+add_library(redscript_lib
+	src/config.cpp
+	src/error.cpp
+    src/file.cpp
+	src/inb.cpp
+	src/lang.cpp
+	src/lexer.cpp
+	src/mc.cpp
+	src/rbc.cpp
+	src/util.cpp
+)
+
+add_executable(redscript_cli entry.cpp)
+target_link_libraries(redscript_cli PRIVATE redscript_lib)
+target_include_directories(redscript_cli PUBLIC src)

--- a/src/error.hpp
+++ b/src/error.hpp
@@ -35,7 +35,7 @@ struct rs_error
              std::string&       _content,
              stack_trace        _trace,
              std::string        _fName,
-             _Args...         _variables) :
+             _Args&&...         _variables) :
                     content(std::make_shared<std::string>(_content)),
                     trace(_trace),
                     fName(_fName),
@@ -48,7 +48,7 @@ struct rs_error
             std::string&       _content,
             raw_trace_info&    _raw,
             std::string        _fName,
-            _Args...         _variables) :
+            _Args&&...         _variables) :
                content(std::make_shared<std::string>(_content)),
                trace{0, std::make_shared<long>(_raw.at), _raw.line, _raw.caret, _raw.nlindex, _raw.start},
                fName(_fName),
@@ -58,7 +58,7 @@ struct rs_error
     }
     rs_error(){}
 
-    
+
 private:
     void _setLine()
     {
@@ -66,9 +66,9 @@ private:
 
         size_t at = *trace.at;
         size_t L  = _content.length();
-    
+
         while (++at < L && _content.at(at) != '\n');
-    
+
         // dont append first \n and last \n to line
         line = _content.substr(trace.nlindex > 0 ? trace.nlindex + 1 : 0, at - trace.nlindex - 1);
     }


### PR DESCRIPTION
Note that the compilation yields one or two errors and a TON of warnings. If you don't want the enormous number of them you can remove -Wextra from the compilation flags, but some of the warnings generated are pretty C++ standard like comparing integers of different sign and others. You've done some work that you haven't pushed upstream yet so maybe the errors will go away after you do, I didn't modify any source files so there shouldn't be any conflict.

Removed the binary redscript file because I don't know why it was there, looks like it was the result of the compilation but pushed to the repo anyway. With CMake the compilation is done inside the `build` folder. You can use it either from the console or from VSCode directly with the right extension.